### PR TITLE
Fix block registry scanning in MappingsReader

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v1.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/mappings/versions/MappingsReader_v1.java
@@ -97,8 +97,9 @@ public class MappingsReader_v1 extends MappingsReader {
                         String identifier = Identifier.formalize(entry.getKey());
                         CustomBlockMapping customBlockMapping = this.readBlockMappingEntry(identifier, entry.getValue());
                         consumer.accept(identifier, customBlockMapping);
-                    } catch (InvalidCustomMappingsFileException e) {
-                        GeyserImpl.getInstance().getLogger().error("Error in registering blocks for custom mapping file: " + file.toString(), e);
+                    } catch (Exception e) {
+                        GeyserImpl.getInstance().getLogger().error("Error in registering blocks for custom mapping file: " + file.toString());
+                        GeyserImpl.getInstance().getLogger().error("due to entry: " + entry, e);
                     }
                 }
             });

--- a/core/src/main/java/org/geysermc/geyser/registry/populator/CustomSkullRegistryPopulator.java
+++ b/core/src/main/java/org/geysermc/geyser/registry/populator/CustomSkullRegistryPopulator.java
@@ -116,7 +116,7 @@ public class CustomSkullRegistryPopulator {
         });
 
         skinHashes.forEach((skinHash) -> {
-            if (!skinHash.matches("^[a-fA-F0-9]{64}$")) {
+            if (!skinHash.matches("^[a-fA-F0-9]+$")) {
                 GeyserImpl.getInstance().getLogger().error("Skin hash " + skinHash + " does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.");
                 return;
             }


### PR DESCRIPTION
Resolves the issues caused by https://github.com/Kas-tle/Geyser/commit/d99cb468f16772ee278da2994a838b2da5f806bb
- `minecraft:dirt` would pick up `minecraft:dirt` and `minecraft:dirt_path` and crash.
- `minecraft:cobblestone_` would be incorrectly accepted, since it picks up `minecraft:cobblestone_stairs`,  `minecraft:cobblestone_slabs` and `minecraft:cobblestone_wall`.

I also removed the 64 character check for skin hashes, since some textures have less than 64 characters.
```
[15:14:31 ERROR] Skin hash df387b69f94feea25671fc399eb75dbeac60f512a4bfe78e454171ee3fc0 does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
[15:14:31 ERROR] Skin hash dfab7daeb8f333c7886a70ef30caf4dec4a8cd10493f23802f1516bdd23fcd does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
[15:14:31 ERROR] Skin hash e126dfae3176f47bad3fae131a66d43a3b4eb7f46df611cae0bf5c382c2b4 does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
[15:14:31 ERROR] Skin hash e6669fe2dbf78792a3e191622a8ed1f9eb803f8826c9b949d0dc15a51c59391 does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
[15:14:31 ERROR] Skin hash e6ad6751595dec669fffc895a1916aff719216f541af112a969351c57be4a8 does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
[15:14:31 ERROR] Skin hash e6e0d5fe87d2d21e2bde6374425a341a7573b375d5bb7d47f4b8dae35297ea4 does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
[15:14:31 ERROR] Skin hash e7c8ac191888c4fca20a68fc230cb83c09aeb6d7bb4b7f4882b091d2def does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
[15:14:31 ERROR] Skin hash ea45d1b417cbddc21767b06044e899b266bf78a66e21876be3c0515ab55d71 does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
[15:14:31 ERROR] Skin hash eeef1056d1149f493b31dac441dc3e964c7dc55d7c323fecd785ee2620abefe does not match required format ^[a-fA-F0-9]{64}$ and will not be added as a custom block.
```